### PR TITLE
Feat: Add TimeDeal list API with status mapping

### DIFF
--- a/src/main/java/goorm/server/timedeal/dto/ResTimeDealListDto.java
+++ b/src/main/java/goorm/server/timedeal/dto/ResTimeDealListDto.java
@@ -1,0 +1,14 @@
+package goorm.server.timedeal.dto;
+
+import java.time.LocalDateTime;
+
+public record ResTimeDealListDto(
+	Long timeDealId,
+	String productName,
+	LocalDateTime startTime,
+	LocalDateTime endTime,
+	Integer stockQuantity,
+	Double discountRate,
+	Integer discountPrice,
+	String status
+) {}

--- a/src/main/java/goorm/server/timedeal/viewcontroller/AdminPageController.java
+++ b/src/main/java/goorm/server/timedeal/viewcontroller/AdminPageController.java
@@ -1,9 +1,14 @@
 package goorm.server.timedeal.viewcontroller;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import goorm.server.timedeal.dto.ResTimeDealListDto;
+import goorm.server.timedeal.service.TimeDealService;
 
 /**
  * 타임딜 관리자 화면
@@ -12,8 +17,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 public class AdminPageController {
 
+	private final TimeDealService timeDealService;
+
+	// 생성자 주입
+	public AdminPageController(TimeDealService timeDealService) {
+		this.timeDealService = timeDealService;
+	}
+
+
 	@GetMapping("")
 	public String showTimeDealReservationPage(Model model) {
-		return "deal_admin";  // 뷰를 반환
+		// 타임딜 리스트 가져오기
+		List<ResTimeDealListDto> timeDeals = timeDealService.getTimeDealList();
+
+		// 모델에 타임딜 리스트 추가
+		model.addAttribute("timeDeals", timeDeals);
+
+		// 뷰 반환
+		return "deal_admin";
 	}
 }

--- a/src/main/resources/templates/deal_admin.html
+++ b/src/main/resources/templates/deal_admin.html
@@ -44,28 +44,18 @@
         <th>재고</th>
         <th>할인율</th>
         <th>할인 후 가격</th>
+        <th>상태</th> <!-- 상태 열 추가 -->
         <th>관리</th>
       </tr>
       </thead>
       <tbody>
-      <!-- 더미 데이터 -->
-      <tr>
-        <td>상품 A</td>
-        <td>2024-12-20 10:00 ~ 2024-12-21 18:00</td>
-        <td>50</td>
-        <td>20%</td>
-        <td>₩46,202</td>
-        <td>
-          <button class="edit-btn">수정</button>
-          <button class="delete-btn">삭제</button>
-        </td>
-      </tr>
-      <tr>
-        <td>상품 B</td>
-        <td>2024-12-22 09:00 ~ 2024-12-23 20:00</td>
-        <td>30</td>
-        <td>15%</td>
-        <td>₩49,390</td>
+      <tr th:each="deal : ${timeDeals}">
+        <td th:text="${deal.productName}">상품명</td>
+        <td th:text="${deal.startTime + ' ~ ' + deal.endTime}">기간</td>
+        <td th:text="${deal.stockQuantity}">재고</td>
+        <td th:text="${deal.discountRate}">할인율</td>
+        <td th:text="${deal.discountPrice}">할인 후 가격</td>
+        <td th:text="${deal.status}">상태</td> <!-- 상태 표시 -->
         <td>
           <button class="edit-btn">수정</button>
           <button class="delete-btn">삭제</button>


### PR DESCRIPTION
타임딜 리스트 조회 API 및 상태 매핑 기능 추가
타임딜 리스트 조회 기능 개발
타임딜 상태(SCHEDULED, ACTIVE, ENDED)를 문자열로 매핑하여 반환
관리자 화면에 타임딜 리스트 표시 가능하도록 연동
검토 후 develop 브랜치로 병합.

관련이슈: #24 