### PR TITLE
🔧 fix: FireLens 구성에서 AWS_Region 제거

### DIFF
--- a/aws/ecs-task-def.json
+++ b/aws/ecs-task-def.json
@@ -101,7 +101,6 @@
           "Host": "${OPENSEARCH_DOMAIN}",
           "Port": "9200",
           "Index": "ecs-logs",
-          "AWS_Region": "ap-northeast-2",
           "AWS_Auth": "On",
           "tls": "On"
         }


### PR DESCRIPTION
firelenes 구성 옵션에서 AWS_Region 옵션은 유효하지 않아서 삭제