### PR TITLE
🔧 fix(ecs): correct ARN value for fluent-bit-config in task definition

### DIFF
--- a/aws/ecs-task-def.json
+++ b/aws/ecs-task-def.json
@@ -96,7 +96,7 @@
       "secrets": [
         {
           "name": "CONFIG_FILE",
-          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:820242919524:secret:fluent-bit-config"
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:820242919524:secret:timdeal-env-GIq81O:fluent-bit-config::"
         }
       ],
 


### PR DESCRIPTION
시크릿 매니저 값을 가져오지 못해 배포중 에러 발생
arn 값 수정.