### PR TITLE
🚀 feat(ecs): Fluent Bit 설정을 S3로 이전

### DIFF
--- a/aws/ecs-task-def.json
+++ b/aws/ecs-task-def.json
@@ -93,10 +93,10 @@
       "memory": 512,
       "essential": true,
 
-      "secrets": [
+      "environment": [
         {
-          "name": "CONFIG_FILE",
-          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:820242919524:secret:fluent-bit-config-EP25Qs"
+          "name": "S3_CONFIG_PATH",
+          "value": "s3://deepdive2team.shop/fluent-bit.conf"
         }
       ],
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,20 @@
 #!/bin/sh
 
-# CONFIG_FILE 환경 변수 내용을 설정 파일로 저장
-echo "$CONFIG_FILE" > /fluent-bit/etc/fluent-bit.conf
+# S3에서 Fluent Bit 설정 파일 다운로드
+echo "Downloading Fluent Bit configuration from S3..."
+aws s3 cp s3://deepdive2team.shop/fluent-bit.conf /fluent-bit/etc/fluent-bit.conf
+
+if [ $? -ne 0 ]; then
+  echo "Failed to download Fluent Bit configuration file. Exiting..."
+  exit 1
+fi
+
+echo "Successfully downloaded Fluent Bit configuration file."
 
 # Fluent Bit 실행 백그라운드로 실행
+echo "Starting Fluent Bit..."
 /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf &
 
 # 애플리케이션 실행
+echo "Starting application..."
 exec java -jar /app/app.jar


### PR DESCRIPTION
- entrypoint.sh`를 수정하여 S3에서 Fluent Bit 설정 파일을 다운로드하도록 변경.
- ecs-task-def.json`에서 Secrets Manager 참조 제거 및 S3 환경 변수 추가.
